### PR TITLE
Fix security scrubbing and null firmware version bugs

### DIFF
--- a/custom_components/yarbo/error_reporting.py
+++ b/custom_components/yarbo/error_reporting.py
@@ -71,7 +71,10 @@ def _scrub_event(event: dict, hint: dict) -> dict:  # type: ignore[type-arg]
             if any(s in key_lower for s in ("password", "token", "secret", "credential")):
                 event["extra"][key] = "[REDACTED]"
             elif (
-                key_lower == "key" or "_key" in key_lower or key_lower.startswith("key_") or key_lower.endswith("key")
+                key_lower == "key"
+                or "_key" in key_lower
+                or key_lower.startswith("key_")
+                or key_lower.endswith("key")
             ) and key_lower not in _KEY_ALLOWLIST:
                 # Catches bare "key", suffix "_key" (api_key), prefix "key_" (key_material,
                 # key_data, key_pair), concatenated suffix "key" (apikey, privatekey), and


### PR DESCRIPTION
- Fix error_reporting.py to catch concatenated key patterns like 'apikey' by adding endswith('key') check
- Fix update.py to properly handle null firmwareVersion from cloud API using result.get() instead of key existence check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small defensive changes to error scrubbing and cloud version parsing, plus targeted tests; main risk is unintended extra redaction of non-sensitive `*key` fields.
> 
> **Overview**
> Improves Sentry/GlitchTip event scrubbing to also redact concatenated `*key` fields (e.g., `apikey`, `privatekey`) in `error_reporting._scrub_event`.
> 
> Hardens the cloud firmware version refresh in `YarboFirmwareUpdate.async_update` to clear cached `latest_firmware_version` when the API response is not a dict or when `firmwareVersion` is missing/`null`, and adds async tests covering these cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aae4ad5805ec433dfd67574b59bd2265e30db3f2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->