### PR TITLE
feat: add firmware update, camera, bag record, diagnostic wifi entities

### DIFF
--- a/custom_components/yarbo/button.py
+++ b/custom_components/yarbo/button.py
@@ -44,6 +44,12 @@ async def async_setup_entry(
             YarboSaveChargingPointButton(coordinator),
             YarboStartHotspotButton(coordinator),
             YarboSaveMapBackupButton(coordinator),
+            # #98 — Camera and firmware commands
+            YarboCameraCalibrationButton(coordinator),
+            YarboCheckCameraStatusButton(coordinator),
+            YarboFirmwareUpdateNowButton(coordinator),
+            YarboFirmwareUpdateTonightButton(coordinator),
+            YarboFirmwareUpdateLaterButton(coordinator),
         ]
     )
 
@@ -261,3 +267,83 @@ class YarboSaveMapBackupButton(YarboButton):
     async def async_press(self) -> None:
         # 🔇 Fire-and-forget: no data_feedback response
         await self._send_command("save_map_backup", {})
+
+
+class YarboCameraCalibrationButton(YarboButton):
+    """Calibrate the robot camera."""
+
+    _attr_translation_key = "camera_calibration"
+    _attr_icon = "mdi:camera-enhance"
+    _attr_entity_category = EntityCategory.CONFIG
+    _attr_entity_registry_enabled_default = False
+
+    def __init__(self, coordinator: YarboDataCoordinator) -> None:
+        super().__init__(coordinator, "camera_calibration")
+
+    async def async_press(self) -> None:
+        # 🔇 Fire-and-forget: no data_feedback response
+        await self._send_command("camera_calibration", {})
+
+
+class YarboCheckCameraStatusButton(YarboButton):
+    """Request current camera status."""
+
+    _attr_translation_key = "check_camera_status"
+    _attr_icon = "mdi:camera-outline"
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_entity_registry_enabled_default = False
+
+    def __init__(self, coordinator: YarboDataCoordinator) -> None:
+        super().__init__(coordinator, "check_camera_status")
+
+    async def async_press(self) -> None:
+        # 🔇 Fire-and-forget: no data_feedback response
+        await self._send_command("check_camera_status", {})
+
+
+class YarboFirmwareUpdateNowButton(YarboButton):
+    """Trigger an immediate firmware update."""
+
+    _attr_translation_key = "firmware_update_now"
+    _attr_icon = "mdi:download-circle"
+    _attr_entity_category = EntityCategory.CONFIG
+    _attr_entity_registry_enabled_default = False
+
+    def __init__(self, coordinator: YarboDataCoordinator) -> None:
+        super().__init__(coordinator, "firmware_update_now")
+
+    async def async_press(self) -> None:
+        # 🔇 Fire-and-forget: no data_feedback response
+        await self._send_command("firmware_update_now", {})
+
+
+class YarboFirmwareUpdateTonightButton(YarboButton):
+    """Schedule a firmware update for tonight."""
+
+    _attr_translation_key = "firmware_update_tonight"
+    _attr_icon = "mdi:download-circle-outline"
+    _attr_entity_category = EntityCategory.CONFIG
+    _attr_entity_registry_enabled_default = False
+
+    def __init__(self, coordinator: YarboDataCoordinator) -> None:
+        super().__init__(coordinator, "firmware_update_tonight")
+
+    async def async_press(self) -> None:
+        # 🔇 Fire-and-forget: no data_feedback response
+        await self._send_command("firmware_update_tonight", {})
+
+
+class YarboFirmwareUpdateLaterButton(YarboButton):
+    """Defer the pending firmware update."""
+
+    _attr_translation_key = "firmware_update_later"
+    _attr_icon = "mdi:update"
+    _attr_entity_category = EntityCategory.CONFIG
+    _attr_entity_registry_enabled_default = False
+
+    def __init__(self, coordinator: YarboDataCoordinator) -> None:
+        super().__init__(coordinator, "firmware_update_later")
+
+    async def async_press(self) -> None:
+        # 🔇 Fire-and-forget: no data_feedback response
+        await self._send_command("firmware_update_later", {})

--- a/custom_components/yarbo/sensor.py
+++ b/custom_components/yarbo/sensor.py
@@ -170,6 +170,8 @@ async def async_setup_entry(
             YarboCleanAreaCountSensor(coordinator),
             YarboMotorTempSensor(coordinator),
             YarboLastSeenSensor(coordinator),
+            # #98 — Saved WiFi networks list
+            YarboSavedWifiListSensor(coordinator),
         ]
     )
 
@@ -1069,7 +1071,11 @@ class YarboPlanRemainingTimeSensor(YarboSensor):
 
 
 class YarboWifiNetworkSensor(YarboSensor):
-    """Diagnostic sensor for connected WiFi network."""
+    """Diagnostic sensor for connected WiFi network.
+
+    Note (#109): this sensor may only return data during active robot operation
+    or when a cloud connection is available. Shows unavailable when idle.
+    """
 
     _attr_entity_category = EntityCategory.DIAGNOSTIC
     _attr_entity_registry_enabled_default = False
@@ -1380,7 +1386,11 @@ class YarboProductCodeSensor(YarboSensor):
 
 
 class YarboHubInfoSensor(YarboSensor):
-    """Hub info sensor."""
+    """Hub info sensor.
+
+    Note (#109): this sensor may only return data during active robot operation
+    or when a cloud connection is available. Shows unavailable when idle.
+    """
 
     _attr_entity_category = EntityCategory.DIAGNOSTIC
     _attr_entity_registry_enabled_default = False
@@ -1418,7 +1428,11 @@ class YarboRechargePointSensor(YarboSensor):
 
 
 class YarboWifiListSensor(YarboSensor):
-    """Available WiFi list sensor."""
+    """Available WiFi list sensor.
+
+    Note (#109): this sensor may only return data during active robot operation
+    or when a cloud connection is available. Shows unavailable when idle.
+    """
 
     _attr_entity_category = EntityCategory.DIAGNOSTIC
     _attr_entity_registry_enabled_default = False
@@ -1501,6 +1515,35 @@ class YarboMotorTempSensor(YarboSensor):
     def native_value(self) -> float | None:
         """Return motor temperature."""
         return self.coordinator.motor_temp_c
+
+
+class YarboSavedWifiListSensor(YarboSensor):
+    """Sensor showing the list of saved (remembered) WiFi networks (#98).
+
+    Note (#109): may only return data during active robot operation
+    or when a cloud connection is available. Shows unavailable when idle.
+    """
+
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_entity_registry_enabled_default = False
+    _attr_translation_key = "saved_wifi_list"
+    _attr_icon = "mdi:wifi-star"
+
+    def __init__(self, coordinator: YarboDataCoordinator) -> None:
+        super().__init__(coordinator, "saved_wifi_list")
+
+    @property
+    def native_value(self) -> str | None:
+        """Return the number of saved WiFi networks, or None when unavailable."""
+        saved = self.coordinator.saved_wifi_list
+        if not saved:
+            return None
+        return str(len(saved))
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return the saved WiFi networks list."""
+        return {"saved_wifi_list": self.coordinator.saved_wifi_list}
 
 
 class YarboLastSeenSensor(YarboSensor):

--- a/custom_components/yarbo/strings.json
+++ b/custom_components/yarbo/strings.json
@@ -78,8 +78,8 @@
       "cannot_connect": "Cannot connect",
       "no_telemetry": "No telemetry received within 30 seconds. Ensure the robot is powered on and near the base station, then try again.",
       "decode_error": "Decode error",
-      "cloud_auth_failed": "Cloud authentication failed \u2014 check your email and password",
-      "cloud_not_available": "Cloud client not available \u2014 update python-yarbo"
+      "cloud_auth_failed": "Cloud authentication failed — check your email and password",
+      "cloud_not_available": "Cloud client not available — update python-yarbo"
     }
   },
   "options": {
@@ -88,7 +88,7 @@
         "title": "Yarbo Options",
         "description": "Configure integration behaviour. Changes take effect immediately (no restart required).",
         "data": {
-          "telemetry_throttle": "Telemetry update interval (1\u201310 seconds)",
+          "telemetry_throttle": "Telemetry update interval (1–10 seconds)",
           "auto_controller": "Auto-acquire controller before commands",
           "cloud_enabled": "Enable cloud features",
           "activity_personality": "Fun activity descriptions (emoji mode)"
@@ -309,6 +309,9 @@
       },
       "last_seen": {
         "name": "Last Seen"
+      },
+      "saved_wifi_list": {
+        "name": "Saved WiFi Networks"
       }
     },
     "binary_sensor": {
@@ -391,6 +394,21 @@
       },
       "save_map_backup": {
         "name": "Save Map Backup"
+      },
+      "camera_calibration": {
+        "name": "Calibrate Camera"
+      },
+      "check_camera_status": {
+        "name": "Check Camera Status"
+      },
+      "firmware_update_now": {
+        "name": "Update Firmware Now"
+      },
+      "firmware_update_tonight": {
+        "name": "Update Firmware Tonight"
+      },
+      "firmware_update_later": {
+        "name": "Defer Firmware Update"
       }
     },
     "event": {
@@ -522,6 +540,9 @@
       },
       "child_lock": {
         "name": "Child Lock"
+      },
+      "bag_record": {
+        "name": "ROS Bag Recording"
       }
     },
     "number": {

--- a/custom_components/yarbo/switch.py
+++ b/custom_components/yarbo/switch.py
@@ -66,6 +66,8 @@ async def async_setup_entry(
             YarboVideoRecordSwitch(coordinator),
             # #113 — Child lock
             YarboChildLockSwitch(coordinator),
+            # #98 — ROS Bag recording
+            YarboBagRecordSwitch(coordinator),
         ]
     )
 
@@ -609,3 +611,15 @@ class YarboChildLockSwitch(YarboCommandSwitch):
             on_value=False,
             off_value=True,
         )
+
+
+class YarboBagRecordSwitch(YarboCommandSwitch):
+    """ROS Bag recording toggle (#98)."""
+
+    _attr_translation_key = "bag_record"
+    _attr_icon = "mdi:record"
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_entity_registry_enabled_default = False
+
+    def __init__(self, coordinator: YarboDataCoordinator) -> None:
+        super().__init__(coordinator, "bag_record", "bag_record", payload_key="state")

--- a/custom_components/yarbo/translations/en.json
+++ b/custom_components/yarbo/translations/en.json
@@ -78,8 +78,8 @@
       "cannot_connect": "Cannot connect",
       "no_telemetry": "No telemetry received within 30 seconds. Ensure the robot is powered on and near the base station, then try again.",
       "decode_error": "Decode error",
-      "cloud_auth_failed": "Cloud authentication failed \u2014 check your email and password",
-      "cloud_not_available": "Cloud client not available \u2014 update python-yarbo"
+      "cloud_auth_failed": "Cloud authentication failed — check your email and password",
+      "cloud_not_available": "Cloud client not available — update python-yarbo"
     }
   },
   "options": {
@@ -88,7 +88,7 @@
         "title": "Yarbo Options",
         "description": "Configure integration behaviour. Changes take effect immediately (no restart required).",
         "data": {
-          "telemetry_throttle": "Telemetry update interval (1\u201310 seconds)",
+          "telemetry_throttle": "Telemetry update interval (1–10 seconds)",
           "auto_controller": "Auto-acquire controller before commands",
           "cloud_enabled": "Enable cloud features",
           "activity_personality": "Fun activity descriptions (emoji mode)",
@@ -313,6 +313,9 @@
       },
       "last_seen": {
         "name": "Last Seen"
+      },
+      "saved_wifi_list": {
+        "name": "Saved WiFi Networks"
       }
     },
     "binary_sensor": {
@@ -395,6 +398,21 @@
       },
       "save_map_backup": {
         "name": "Save Map Backup"
+      },
+      "camera_calibration": {
+        "name": "Calibrate Camera"
+      },
+      "check_camera_status": {
+        "name": "Check Camera Status"
+      },
+      "firmware_update_now": {
+        "name": "Update Firmware Now"
+      },
+      "firmware_update_tonight": {
+        "name": "Update Firmware Tonight"
+      },
+      "firmware_update_later": {
+        "name": "Defer Firmware Update"
       }
     },
     "event": {
@@ -526,6 +544,9 @@
       },
       "child_lock": {
         "name": "Child Lock"
+      },
+      "bag_record": {
+        "name": "ROS Bag Recording"
       }
     },
     "number": {

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -275,3 +275,106 @@ class TestYarboSaveMapBackupButton:
 
         coord.client.get_controller.assert_called_once_with(timeout=5.0)
         coord.client.publish_command.assert_called_once_with("save_map_backup", {})
+
+
+# ---- imports for new entities ----
+from custom_components.yarbo.button import (  # noqa: E402
+    YarboCameraCalibrationButton,
+    YarboCheckCameraStatusButton,
+    YarboFirmwareUpdateLaterButton,
+    YarboFirmwareUpdateNowButton,
+    YarboFirmwareUpdateTonightButton,
+)
+
+
+class TestYarboCameraCalibrationButton:
+    """Tests for camera calibration button."""
+
+    def test_disabled_by_default(self) -> None:
+        coord = _make_coordinator()
+        assert YarboCameraCalibrationButton(coord).entity_registry_enabled_default is False
+
+    def test_entity_category(self) -> None:
+        coord = _make_coordinator()
+        assert YarboCameraCalibrationButton(coord).entity_category == EntityCategory.CONFIG
+
+    @pytest.mark.asyncio
+    async def test_press_publishes_command(self) -> None:
+        coord = _make_coordinator()
+        entity = YarboCameraCalibrationButton(coord)
+        with patch.object(entity, "async_write_ha_state"):
+            await entity.async_press()
+        coord.client.get_controller.assert_called_once_with(timeout=5.0)
+        coord.client.publish_command.assert_called_once_with("camera_calibration", {})
+
+
+class TestYarboCheckCameraStatusButton:
+    """Tests for check camera status button."""
+
+    def test_disabled_by_default(self) -> None:
+        coord = _make_coordinator()
+        assert YarboCheckCameraStatusButton(coord).entity_registry_enabled_default is False
+
+    @pytest.mark.asyncio
+    async def test_press_publishes_command(self) -> None:
+        coord = _make_coordinator()
+        entity = YarboCheckCameraStatusButton(coord)
+        with patch.object(entity, "async_write_ha_state"):
+            await entity.async_press()
+        coord.client.get_controller.assert_called_once_with(timeout=5.0)
+        coord.client.publish_command.assert_called_once_with("check_camera_status", {})
+
+
+class TestYarboFirmwareUpdateNowButton:
+    """Tests for firmware update now button."""
+
+    def test_disabled_by_default(self) -> None:
+        coord = _make_coordinator()
+        assert YarboFirmwareUpdateNowButton(coord).entity_registry_enabled_default is False
+
+    def test_entity_category(self) -> None:
+        coord = _make_coordinator()
+        assert YarboFirmwareUpdateNowButton(coord).entity_category == EntityCategory.CONFIG
+
+    @pytest.mark.asyncio
+    async def test_press_publishes_command(self) -> None:
+        coord = _make_coordinator()
+        entity = YarboFirmwareUpdateNowButton(coord)
+        with patch.object(entity, "async_write_ha_state"):
+            await entity.async_press()
+        coord.client.get_controller.assert_called_once_with(timeout=5.0)
+        coord.client.publish_command.assert_called_once_with("firmware_update_now", {})
+
+
+class TestYarboFirmwareUpdateTonightButton:
+    """Tests for firmware update tonight button."""
+
+    def test_disabled_by_default(self) -> None:
+        coord = _make_coordinator()
+        assert YarboFirmwareUpdateTonightButton(coord).entity_registry_enabled_default is False
+
+    @pytest.mark.asyncio
+    async def test_press_publishes_command(self) -> None:
+        coord = _make_coordinator()
+        entity = YarboFirmwareUpdateTonightButton(coord)
+        with patch.object(entity, "async_write_ha_state"):
+            await entity.async_press()
+        coord.client.get_controller.assert_called_once_with(timeout=5.0)
+        coord.client.publish_command.assert_called_once_with("firmware_update_tonight", {})
+
+
+class TestYarboFirmwareUpdateLaterButton:
+    """Tests for firmware update later button."""
+
+    def test_disabled_by_default(self) -> None:
+        coord = _make_coordinator()
+        assert YarboFirmwareUpdateLaterButton(coord).entity_registry_enabled_default is False
+
+    @pytest.mark.asyncio
+    async def test_press_publishes_command(self) -> None:
+        coord = _make_coordinator()
+        entity = YarboFirmwareUpdateLaterButton(coord)
+        with patch.object(entity, "async_write_ha_state"):
+            await entity.async_press()
+        coord.client.get_controller.assert_called_once_with(timeout=5.0)
+        coord.client.publish_command.assert_called_once_with("firmware_update_later", {})

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -69,6 +69,7 @@ def _make_coordinator(**telemetry_kwargs: object) -> MagicMock:
     coord.recharge_point_status = None
     coord.recharge_point_details = None
     coord.wifi_list = []
+    coord.saved_wifi_list = []
     coord.map_backups = []
     coord.clean_areas = []
     coord.motor_temp_c = None
@@ -688,4 +689,35 @@ class TestYarboLastSeenSensor:
         coord = _make_coordinator()
         coord.last_seen = None
         entity = YarboLastSeenSensor(coord)
+        assert entity.entity_registry_enabled_default is False
+
+
+from custom_components.yarbo.sensor import YarboSavedWifiListSensor  # noqa: E402
+
+
+class TestYarboSavedWifiListSensor:
+    """Tests for saved WiFi list sensor (#98)."""
+
+    def test_no_data_returns_none(self) -> None:
+        coord = _make_coordinator()
+        coord.saved_wifi_list = []
+        entity = YarboSavedWifiListSensor(coord)
+        assert entity.native_value is None
+
+    def test_count_returned_as_string(self) -> None:
+        coord = _make_coordinator()
+        coord.saved_wifi_list = [{"ssid": "HomeNet"}, {"ssid": "GuestNet"}]
+        entity = YarboSavedWifiListSensor(coord)
+        assert entity.native_value == "2"
+
+    def test_extra_attributes_contain_list(self) -> None:
+        coord = _make_coordinator()
+        networks = [{"ssid": "HomeNet"}]
+        coord.saved_wifi_list = networks
+        entity = YarboSavedWifiListSensor(coord)
+        assert entity.extra_state_attributes == {"saved_wifi_list": networks}
+
+    def test_disabled_by_default(self) -> None:
+        coord = _make_coordinator()
+        entity = YarboSavedWifiListSensor(coord)
         assert entity.entity_registry_enabled_default is False

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -811,3 +811,33 @@ class TestYarboSoundEnableSwitch:
 
         coord.client.publish_command.assert_called_with("set_sound_param", {"enable": 0})
         assert entity.is_on is False
+
+
+from custom_components.yarbo.switch import YarboBagRecordSwitch  # noqa: E402
+
+
+class TestYarboBagRecordSwitch:
+    """Tests for ROS Bag recording switch (#98)."""
+
+    def test_disabled_by_default(self) -> None:
+        coord = _make_coordinator()
+        assert YarboBagRecordSwitch(coord).entity_registry_enabled_default is False
+
+    @pytest.mark.asyncio
+    async def test_turn_on(self) -> None:
+        coord = _make_coordinator()
+        entity = YarboBagRecordSwitch(coord)
+        with patch.object(entity, "async_write_ha_state"):
+            await entity.async_turn_on()
+        coord.client.publish_command.assert_called_once_with("bag_record", {"state": 1})
+        assert entity.is_on is True
+
+    @pytest.mark.asyncio
+    async def test_turn_off(self) -> None:
+        coord = _make_coordinator()
+        entity = YarboBagRecordSwitch(coord)
+        with patch.object(entity, "async_write_ha_state"):
+            await entity.async_turn_on()
+            await entity.async_turn_off()
+        coord.client.publish_command.assert_called_with("bag_record", {"state": 0})
+        assert entity.is_on is False


### PR DESCRIPTION
## Summary

Implements #98 and #109.

### #98 — New button entities
- **Calibrate Camera** (`camera_calibration`) — sends `camera_calibration` command
- **Check Camera Status** (`check_camera_status`) — sends `check_camera_status` command
- **Update Firmware Now** (`firmware_update_now`) — triggers immediate firmware update
- **Update Firmware Tonight** (`firmware_update_tonight`) — schedules update for tonight
- **Defer Firmware Update** (`firmware_update_later`) — defers pending update

### #98 — New switch entity
- **ROS Bag Recording** (`bag_record`) — toggles ROS bag recording on/off

### #98 — New sensor entity
- **Saved WiFi Networks** (`saved_wifi_list`) — shows count of saved WiFi networks with list in attributes; calls `get_saved_wifi_list` via coordinator

### #109 — Diagnostic WiFi/hub sensors
- Added docstring notes to `wifi_list`, `hub_info`, and `wifi_network` sensors noting they may require active robot state
- All three were already marked `entity_category: diagnostic` ✓

### Tests
- Added tests for all 5 new button entities, the bag record switch, and the saved WiFi list sensor
- **400 tests pass**, 4 skipped

Closes #98, #109

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new command entities that can trigger disruptive device actions (firmware update, camera calibration, ROS bag recording), though all are disabled by default and mostly fire-and-forget publishes. Also introduces new coordinator state/parsing for saved WiFi lists, which could surface as unavailable/incorrect data if payload formats differ.
> 
> **Overview**
> Adds several new **disabled-by-default** command entities: buttons for `camera_calibration`, `check_camera_status`, and firmware update actions (`firmware_update_now`/`tonight`/`later`), plus a diagnostic `bag_record` switch.
> 
> Extends the coordinator with `get_saved_wifi_list` and exposes `saved_wifi_list`, and adds a `saved_wifi_list` diagnostic sensor that reports the count and includes the full list as attributes; also updates diagnostic sensor docstrings to note some values may be unavailable while idle.
> 
> Updates translations/strings for the new entities (and minor punctuation fixes) and adds unit tests covering the new buttons, switch, and sensor.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eb61a21186d9ebe8a3e0636ae5e24a57e032341b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->