### PR TITLE
feat: sentry-sdk mandatory + error reporting opt-out toggle

### DIFF
--- a/custom_components/yarbo/__init__.py
+++ b/custom_components/yarbo/__init__.py
@@ -32,7 +32,9 @@ from .const import (
     CONF_ROBOT_SERIAL,
     DATA_CLIENT,
     DATA_COORDINATOR,
+    DEFAULT_ERROR_REPORTING,
     DOMAIN,
+    OPT_ERROR_REPORTING,
     PLATFORMS,
 )
 from .coordinator import YarboDataCoordinator
@@ -107,13 +109,12 @@ def _warmup_connect(host: str, port: int) -> None:
     (idna metadata, etc.) happen outside the event loop.
     """
     try:
-        import socket
-
         # Force idna and other lazy imports to resolve their metadata now
         # Force all lazy imports and metadata reads that paho-mqtt triggers
         # during connect. These must happen in the executor thread, not the
         # event loop, to avoid HA's blocking call detection.
         import importlib.metadata
+        import socket
 
         for pkg in ("idna", "paho-mqtt", "certifi", "charset-normalizer"):
             try:
@@ -124,10 +125,10 @@ def _warmup_connect(host: str, port: int) -> None:
                 pass
         # Pre-import idna and force its __version__ lookup (which reads METADATA)
         try:
-            import idna  # noqa: F401
-            import idna.core  # noqa: F401
-            import idna.codec  # noqa: F401
-            import idna.package_data  # noqa: F401
+            import idna
+            import idna.codec
+            import idna.core
+            import idna.package_data
 
             _ = idna.__version__  # triggers metadata read
         except (ImportError, AttributeError):
@@ -137,7 +138,7 @@ def _warmup_connect(host: str, port: int) -> None:
         s.settimeout(3)
         s.connect((host, port))
         s.close()
-    except Exception:  # noqa: BLE001
+    except Exception:
         pass  # Warmup failure is non-fatal
 
 
@@ -187,10 +188,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     except Exception as err:
         _LOGGER.debug("Could not fetch integration version: %s", err)
 
-    # Opt-in error reporting: set YARBO_SENTRY_DSN to enable
+    # Opt-in error reporting: read option, default enabled during beta
     _serial = entry.data.get(CONF_ROBOT_SERIAL, "unknown")
+    error_reporting_enabled = entry.options.get(OPT_ERROR_REPORTING, DEFAULT_ERROR_REPORTING)
     await async_init_error_reporting(
         hass,
+        enabled=error_reporting_enabled,
         tags={
             "integration": DOMAIN,
             "integration_version": integration_version,
@@ -207,7 +210,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             entry.data[CONF_BROKER_HOST],
             entry.data[CONF_BROKER_PORT],
         )
-    except Exception:  # noqa: BLE001
+    except Exception:
         _LOGGER.debug("Warmup connect failed (non-fatal)")
 
     client = YarboLocalClient(

--- a/custom_components/yarbo/config_flow.py
+++ b/custom_components/yarbo/config_flow.py
@@ -90,6 +90,7 @@ from .const import (  # noqa: E402
     DEFAULT_AUTO_CONTROLLER,
     DEFAULT_BROKER_PORT,
     DEFAULT_DEBUG_LOGGING,
+    DEFAULT_ERROR_REPORTING,
     DEFAULT_MQTT_RECORDING,
     DEFAULT_TELEMETRY_THROTTLE,
     DOMAIN,
@@ -98,6 +99,7 @@ from .const import (  # noqa: E402
     OPT_ACTIVITY_PERSONALITY,
     OPT_AUTO_CONTROLLER,
     OPT_DEBUG_LOGGING,
+    OPT_ERROR_REPORTING,
     OPT_MQTT_RECORDING,
     OPT_TELEMETRY_THROTTLE,
 )
@@ -787,6 +789,12 @@ class YarboOptionsFlow(OptionsFlow):
                     OPT_ACTIVITY_PERSONALITY,
                     default=self._config_entry.options.get(
                         OPT_ACTIVITY_PERSONALITY, DEFAULT_ACTIVITY_PERSONALITY
+                    ),
+                ): bool,
+                vol.Optional(
+                    OPT_ERROR_REPORTING,
+                    default=self._config_entry.options.get(
+                        OPT_ERROR_REPORTING, DEFAULT_ERROR_REPORTING
                     ),
                 ): bool,
             }

--- a/custom_components/yarbo/const.py
+++ b/custom_components/yarbo/const.py
@@ -218,4 +218,8 @@ OPT_DEBUG_LOGGING = "debug_logging"
 OPT_MQTT_RECORDING = "mqtt_recording"
 DEFAULT_DEBUG_LOGGING = False
 DEFAULT_MQTT_RECORDING = False
+
+# Error reporting opt-out
+OPT_ERROR_REPORTING = "error_reporting"
+DEFAULT_ERROR_REPORTING = True  # enabled by default during beta
 MQTT_RECORDING_MAX_SIZE_BYTES = 10 * 1024 * 1024  # 10 MB

--- a/custom_components/yarbo/manifest.json
+++ b/custom_components/yarbo/manifest.json
@@ -17,7 +17,8 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/markus-lassfolk/home-assistant-yarbo/issues",
   "requirements": [
-    "python-yarbo>=2026.3.21,<2027.0"
+    "python-yarbo>=2026.3.21,<2027.0",
+    "sentry-sdk>=1.0.0"
   ],
   "version": "2026.3.23"
 }

--- a/custom_components/yarbo/translations/en.json
+++ b/custom_components/yarbo/translations/en.json
@@ -93,7 +93,8 @@
           "cloud_enabled": "Enable cloud features",
           "activity_personality": "Fun activity descriptions (emoji mode)",
           "debug_logging": "Enable debug logging",
-          "mqtt_recording": "Record MQTT traffic for diagnostics"
+          "mqtt_recording": "Record MQTT traffic for diagnostics",
+          "error_reporting": "Enable anonymous crash reporting (helps improve the integration)"
         },
         "data_description": {
           "telemetry_throttle": "How often telemetry updates are pushed to Home Assistant. Lower values mean more frequent updates but higher recorder load.",


### PR DESCRIPTION
- Add sentry-sdk>=1.0.0 to manifest.json (HA auto-installs)
- Add opt-out toggle in integration options (Settings > Integrations > Yarbo > Configure)
- Default: enabled during beta
- Reads from config entry options, reloads on change

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new always-installed `sentry-sdk` dependency and enables crash reporting by default (beta) based on config entry options, which can impact privacy/telemetry expectations and startup behavior.
> 
> **Overview**
> Adds **anonymous crash reporting** support via `sentry-sdk` as a Home Assistant requirement, and makes it **configurable via an opt-out option** (`error_reporting`) in the integration’s options UI (default on during beta).
> 
> Wires the option into `async_setup_entry` so `async_init_error_reporting(..., enabled=...)` reflects user choice, and updates constants/translations accordingly; includes small warmup-connect cleanup (import ordering and broad exception linting).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 39ddcbcf565505eb89fdc8e64cec408a49c72305. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->