### PR TITLE
fix: replace MAC OUI filter with parallel MQTT port probing

### DIFF
--- a/custom_components/yarbo/discovery.py
+++ b/custom_components/yarbo/discovery.py
@@ -2,11 +2,15 @@
 
 This module attempts to discover Yarbo MQTT brokers using the python-yarbo
 library's discover() API when available. When the library provides no discovery,
-it falls back to scanning the local ARP table via 'ip neigh' for devices with
-the Yarbo OUI (C8:FE:0F). Discovered hosts are normalized to YarboEndpoint
-objects with colon-delimited MACs and a canonical endpoint_type. If discovery
-yields no results, a seed_host (e.g. from DHCP) is used as a single fallback
-endpoint so the config flow can still proceed.
+it falls back to scanning the local ARP table via 'ip neigh' and probing each
+host for an MQTT broker on the configured port. This approach is MAC-agnostic
+and works with any Yarbo hardware revision regardless of WiFi chipset vendor.
+
+Discovered hosts are normalized to YarboEndpoint objects with colon-delimited
+MACs and a canonical endpoint_type. If discovery yields no results, a seed_host
+(e.g. from DHCP) is used as a single fallback endpoint so the config flow can
+still proceed.
+
 See: https://github.com/markus-lassfolk/home-assistant-yarbo/issues/50
 """
 
@@ -24,6 +28,13 @@ from .const import (
 )
 
 _LOGGER = logging.getLogger(__name__)
+
+# Timeout for each MQTT port probe (seconds).
+# Connection-refused is instant; only unreachable hosts hit the timeout.
+_PROBE_TIMEOUT = 1.5
+
+# Maximum number of parallel probes to avoid flooding the network.
+_MAX_CONCURRENT_PROBES = 30
 
 
 @dataclass
@@ -83,16 +94,33 @@ def _from_library_result(r: object, port: int) -> YarboEndpoint | None:
     )
 
 
-YARBO_OUI = "c8:fe:0f"
+async def _probe_mqtt(host: str, port: int) -> bool:
+    """Try to open a TCP connection to host:port.
+
+    Returns True if the port is open (MQTT broker likely running).
+    Fails fast on connection-refused; times out on unreachable hosts.
+    """
+    try:
+        _reader, writer = await asyncio.wait_for(
+            asyncio.open_connection(host, port),
+            timeout=_PROBE_TIMEOUT,
+        )
+        writer.close()
+        await writer.wait_closed()
+        return True
+    except (OSError, TimeoutError):
+        return False
 
 
 async def _discover_from_arp(port: int = DEFAULT_BROKER_PORT) -> list[YarboEndpoint]:
-    """Scan the local ARP table for Yarbo devices (MAC OUI C8:FE:0F).
+    """Scan the ARP table and probe each neighbour for an MQTT broker.
 
-    Uses 'ip neigh' on Linux to read the ARP table without requiring
-    any network scanning. Fast and non-intrusive.
+    Reads 'ip neigh' to get all known hosts on the local network, then
+    probes each one in parallel for an open MQTT port. No MAC filtering —
+    works with any Yarbo hardware revision regardless of chipset vendor.
     """
-    endpoints: list[YarboEndpoint] = []
+    # Collect all ARP neighbours with their MACs
+    neighbours: list[tuple[str, str]] = []  # (ip, mac)
     try:
         proc = await asyncio.create_subprocess_exec(
             "ip",
@@ -103,25 +131,48 @@ async def _discover_from_arp(port: int = DEFAULT_BROKER_PORT) -> list[YarboEndpo
         stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=5.0)
         for line in stdout.decode(errors="replace").splitlines():
             parts = line.split()
-            # Format: 192.168.1.24 dev eth0 lladdr c8:fe:0f:xx:xx:xx REACHABLE
             if len(parts) >= 5 and "lladdr" in parts:
                 ip = parts[0]
                 mac_idx = parts.index("lladdr") + 1
                 if mac_idx < len(parts):
                     mac = parts[mac_idx].lower()
-                    if mac.startswith(YARBO_OUI):
-                        _LOGGER.debug("ARP discovery: found Yarbo at %s (MAC %s)", ip, mac)
-                        endpoints.append(
-                            YarboEndpoint(
-                                host=ip,
-                                port=port,
-                                mac=mac,  # already colon-delimited from 'ip neigh'
-                                endpoint_type=ENDPOINT_TYPE_UNKNOWN,
-                                recommended=False,
-                            )
-                        )
+                    neighbours.append((ip, mac))
     except (FileNotFoundError, TimeoutError, OSError) as err:
         _LOGGER.debug("ARP scan failed: %s", err)
+        return []
+
+    if not neighbours:
+        return []
+
+    _LOGGER.debug(
+        "ARP discovery: probing %d neighbours for MQTT on port %d",
+        len(neighbours),
+        port,
+    )
+
+    # Probe all neighbours in parallel with concurrency limit
+    semaphore = asyncio.Semaphore(_MAX_CONCURRENT_PROBES)
+
+    async def _limited_probe(ip: str) -> bool:
+        async with semaphore:
+            return await _probe_mqtt(ip, port)
+
+    results = await asyncio.gather(*[_limited_probe(ip) for ip, _mac in neighbours])
+
+    endpoints: list[YarboEndpoint] = []
+    for (ip, mac), is_open in zip(neighbours, results, strict=True):
+        if is_open:
+            _LOGGER.debug("ARP discovery: found MQTT broker at %s (MAC %s)", ip, mac)
+            endpoints.append(
+                YarboEndpoint(
+                    host=ip,
+                    port=port,
+                    mac=mac,
+                    endpoint_type=ENDPOINT_TYPE_UNKNOWN,
+                    recommended=False,
+                )
+            )
+
     return endpoints
 
 
@@ -143,7 +194,7 @@ async def async_discover_endpoints(
         yarbo_discover = None
 
     if yarbo_discover is None:
-        # Library has no discover() yet — fall back to ARP table scan
+        # Library has no discover() yet — fall back to ARP + MQTT probe
         endpoints = await _discover_from_arp(port)
         if endpoints:
             return endpoints
@@ -164,7 +215,9 @@ async def async_discover_endpoints(
         if asyncio.iscoroutinefunction(yarbo_discover):
             results = await asyncio.wait_for(yarbo_discover(port=port), timeout=10.0)
         else:
-            results = await asyncio.wait_for(asyncio.to_thread(yarbo_discover, port=port), timeout=10.0)
+            results = await asyncio.wait_for(
+                asyncio.to_thread(yarbo_discover, port=port), timeout=10.0
+            )
     except Exception as err:
         _LOGGER.debug("yarbo.discover() failed: %s", err)
         results = []


### PR DESCRIPTION
Removes hardcoded C8:FE:0F MAC filter. Probes ALL ARP neighbours for MQTT port instead. Fixes discovery for Yarbo units with different WiFi chipsets (reported: 3C:AB:72, 78:22:88).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes network discovery behavior to actively open TCP connections to many ARP neighbours, which could increase startup latency or network load on some LANs despite added timeouts and concurrency limits.
> 
> **Overview**
> Makes ARP-based discovery **MAC-agnostic** by removing the hardcoded Yarbo OUI filter and instead probing every `ip neigh` entry for an open MQTT port.
> 
> Adds async TCP probing (`_probe_mqtt`) with a per-host timeout and a concurrency limit, returning endpoints only for hosts with the broker port reachable; updates fallback messaging/logging to reflect the new ARP+probe approach.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a70130b68b48cf4720674dd27e9c9afd160e76ba. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->